### PR TITLE
Dumpdatabase can be able to apply extra params from database config

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -2,22 +2,22 @@
 
 return [
     'development' => [
-        'type' => 'mysql',
-        'host' => 'localhost',
-        'port' => '3306',
-        'user' => 'root',
-        'pass' => 'password',
-        'database' => 'test',
+        'type'              => 'mysql',
+        'host'              => 'localhost',
+        'port'              => '3306',
+        'user'              => 'root',
+        'pass'              => 'password',
+        'database'          => 'test',
         'singleTransaction' => false,
-        'ignoreTables' => [],
-        'extra_params' => []
+        'ignoreTables'      => [],
+        'verbose'           => false
     ],
-    'production' => [
-        'type' => 'postgresql',
-        'host' => 'localhost',
-        'port' => '5432',
-        'user' => 'postgres',
-        'pass' => 'password',
+    'production'  => [
+        'type'     => 'postgresql',
+        'host'     => 'localhost',
+        'port'     => '5432',
+        'user'     => 'postgres',
+        'pass'     => 'password',
         'database' => 'test',
     ],
 ];

--- a/config/database.php
+++ b/config/database.php
@@ -10,6 +10,7 @@ return [
         'database' => 'test',
         'singleTransaction' => false,
         'ignoreTables' => [],
+        'extra_params' => []
     ],
     'production' => [
         'type' => 'postgresql',

--- a/src/Databases/MysqlDatabase.php
+++ b/src/Databases/MysqlDatabase.php
@@ -40,8 +40,12 @@ class MysqlDatabase implements Database {
         if (array_key_exists('ssl', $this->config) && $this->config['ssl'] === true) {
     		$extras[] = '--ssl';
     	}
+
+    	$extras = array_merge($extras, $this->addExtraParamsFromConfig());
+
     	$command = 'mysqldump --routines '.implode(' ', $extras).' --host=%s --port=%s --user=%s --password=%s %s > %s';
-        return sprintf($command,
+
+    	return sprintf($command,
             escapeshellarg($this->config['host']),
             escapeshellarg($this->config['port']),
             escapeshellarg($this->config['user']),
@@ -49,6 +53,28 @@ class MysqlDatabase implements Database {
             escapeshellarg($this->config['database']),
             escapeshellarg($outputPath)
         );
+    }
+
+    private function addExtraParamsFromConfig()
+    {
+        if (!isset($this->config['extra_params']) || !is_array($this->config['extra_params'])) {
+            return [];
+        }
+
+        $extraParams = [];
+
+        foreach ($this->config['extra_params'] as $param => $value) {
+            $no_value_param = is_numeric($param);
+
+            if ($no_value_param) {
+                $extraParams[] = '--' . $value;
+                continue;
+            }
+
+            $extraParams[] = '--' . $param . '=\'' . $value . '\'';
+        }
+
+        return $extraParams;
     }
 
     /**
@@ -90,7 +116,7 @@ class MysqlDatabase implements Database {
                 escapeshellarg($ignoreTable)
             );
         }
-        
+
         return implode(' ',$commands);
     }
 }

--- a/src/Databases/MysqlDatabase.php
+++ b/src/Databases/MysqlDatabase.php
@@ -40,8 +40,9 @@ class MysqlDatabase implements Database {
         if (array_key_exists('ssl', $this->config) && $this->config['ssl'] === true) {
     		$extras[] = '--ssl';
     	}
-
-    	$extras = array_merge($extras, $this->addExtraParamsFromConfig());
+    	if (array_key_exists('verbose', $this->config) && $this->config['verbose'] === true) {
+    		$extras[] = '--verbose';
+    	}
 
     	$command = 'mysqldump --routines '.implode(' ', $extras).' --host=%s --port=%s --user=%s --password=%s %s > %s';
 
@@ -53,28 +54,6 @@ class MysqlDatabase implements Database {
             escapeshellarg($this->config['database']),
             escapeshellarg($outputPath)
         );
-    }
-
-    private function addExtraParamsFromConfig()
-    {
-        if (!isset($this->config['extra_params']) || !is_array($this->config['extra_params'])) {
-            return [];
-        }
-
-        $extraParams = [];
-
-        foreach ($this->config['extra_params'] as $param => $value) {
-            $no_value_param = is_numeric($param);
-
-            if ($no_value_param) {
-                $extraParams[] = '--' . $value;
-                continue;
-            }
-
-            $extraParams[] = '--' . $param . '=\'' . $value . '\'';
-        }
-
-        return $extraParams;
     }
 
     /**


### PR DESCRIPTION
Iep @obokaman-com ,

He afegit la possibilitat d'afegir paràmetres opcionals i així poder afegir el paràmetre verbose.

Només cal afegir al config de `database.php`:

```php
return [
    'databaseXXX' => [
         'extra_params' => [
              'verbose'
         ]
    ]
]